### PR TITLE
add: getShortestPathCost()

### DIFF
--- a/src/main/kotlin/graph/dijkstra/Dijkstra.kt
+++ b/src/main/kotlin/graph/dijkstra/Dijkstra.kt
@@ -3,6 +3,7 @@ package graph.dijkstra
 class Dijkstra() {
 
     private val ansList: List<List<List<Int>>>
+    private val shortestPathCosts = mutableListOf<Map<Int, Int>>()
     private val edges: List<List<Int>>
     private val nodeNumber: Int
     private val id: IntRange
@@ -40,7 +41,10 @@ class Dijkstra() {
         return ansList[startNode]
     }
 
-
+    // 最短経路のコストを返す
+    fun getShortestPathCost(startNode: Int, goalNode: Int): Int {
+        return shortestPathCosts[startNode][goalNode] ?: throw IllegalArgumentException("don't exist node. startNode: $startNode goalNode: $goalNode")
+    }
 
     private fun solveAllCondition(): List<List<List<Int>>> {
 
@@ -89,8 +93,8 @@ class Dijkstra() {
 
             parentsList.add(list.toList().reversed())
         }
+        shortestPathCosts.add(nodeCostList)
         return parentsList.toList()
-
     }
 
     private fun getMinCostNode(nodeCostList: MutableMap<Int, Int>, nodeIsVisited: MutableMap<Int, Boolean>): Int { // 最小コストノードのID

--- a/src/test/kotlin/graph/dijkstra/DijkstraTest.kt
+++ b/src/test/kotlin/graph/dijkstra/DijkstraTest.kt
@@ -73,4 +73,29 @@ internal class DijkstraTest() {
         assertEquals(ans1to1, expect1to1)
         assertEquals(ans0to2, expect0to2)
     }
+    @Test
+    internal fun test_getShortestPathCost() {
+        input.inputln("6 8")
+        input.inputln("0 1 6")
+        input.inputln("0 5 3")
+        input.inputln("1 2 3")
+        input.inputln("2 3 1")
+        input.inputln("2 4 3")
+        input.inputln("2 5 5")
+        input.inputln("3 4 1")
+        input.inputln("4 5 2")
+
+        val dijkstra = Dijkstra()
+        val ans0to1 = dijkstra.getShortestPathCost(0, 1)
+        val ans1to1 = dijkstra.getShortestPathCost(1, 1)
+        val ans0to2 = dijkstra.getShortestPathCost(0, 2)
+
+        val expect0to1 = 6
+        val expect1to1 = 0
+        val expect0to2 = 7
+
+        assertEquals(ans0to1, expect0to1)
+        assertEquals(ans1to1, expect1to1)
+        assertEquals(ans0to2, expect0to2)
+    }
 }


### PR DESCRIPTION
Closes #2 

# 概要

- 最短経路のコストを出力する関数の作成
 
# 目的

- 最短経路のコストを取得できなかったため

# 方法

- shortestPathCosts: MutableList<Map<Int, Int>>の作成
  - solve()内で計算したnodeCostListをまとめたもの
- getShortestPathCost(startNode: Int, goalNode: Int): Intの作成
  - Dijkstraクラス内のshortestPathCostsを参照し、startNode-goalNode間のコストを返す